### PR TITLE
fix for #18 ("view form data not possible with non-admin users")

### DIFF
--- a/dca/tl_lead_data.php
+++ b/dca/tl_lead_data.php
@@ -119,7 +119,7 @@ class tl_lead_data extends Backend
             \Controller::redirect('contao/main.php?act=error');
         }
 
-        $objLeads = \Database::getInstance()->prepare("SELECT master_id FROM tl_lead WHERE id=(SELECT pid FROM tl_lead_data WHERE id=?)")
+        $objLeads = \Database::getInstance()->prepare("SELECT master_id FROM tl_lead WHERE id=?")
                                             ->limit(1)
                                             ->execute(\Input::get('id'));
 


### PR DESCRIPTION
This finally fixes #18. To clarify again: the GET parameter `id` is a `tl_lead` ID, not a `tl_lead_data` ID. The SQL query originally however treated it as a `tl_lead_data` ID, using a sub query to get a `tl_lead` ID - thus `$objLeads` will usually be empty, unless a `tl_lead_data` coincides with a `tl_lead` ID (which would only happen in the beginning, when you have fresh data).