### PR TITLE
use numeric date format for date/time fields

### DIFF
--- a/library/Leads/Leads.php
+++ b/library/Leads/Leads.php
@@ -41,8 +41,8 @@ class Leads extends \Controller
 
         // Convert date formats into timestamps
         if ($varValue != '' && in_array($objField->rgxp, array('date', 'time', 'datim'))) {
-            $key      = $objField->rgxp . 'Format';
-            $format   = isset($GLOBALS['objPage']) ? $GLOBALS['objPage']->{$key} : $GLOBALS['TL_CONFIG'][$key];
+            $function = 'getNumeric' . ucfirst($objField->rgxp) . 'Format';
+            $format   = \Date::{$function}();
             $objDate  = new \Date($varValue, $format);
             $varValue = $objDate->tstamp;
         }


### PR DESCRIPTION
Consider the following setup:

* A website root with a `dateFormat` setting of `j. F Y` (to generate the front-end output of _28. März 2017_ for example).
* A form with a leads setting.
* An input field with `rgxp` set to `date` and configured to be saved in the lead.

Now, when you submit the form, the following error will occur:
```
Fatal error: Uncaught exception Exception with message Invalid date format "j. F Y" thrown in system/modules/core/library/Contao/Date.php on line 329

#0 system/modules/core/library/Contao/Date.php(79): Contao\Date->dateToUnix()
#1 composer/vendor/terminal42/contao-leads/library/Leads/Leads.php(46): Contao\Date->__construct('1981-01-01', 'j. F Y')
#2 composer/vendor/terminal42/contao-leads/library/Leads/Leads.php(272): Leads\Leads::prepareValue('1981-01-01', Object(Contao\Database\Mysqli\Result))
#3 system/modules/core/forms/Form.php(520): Leads\Leads->processFormData(Array, Array, Array, Array, Object(Contao\Form))
#4 system/modules/core/forms/Form.php(249): Contao\Form->processFormData(Array, Array, Array)
#5 system/modules/core/classes/Hybrid.php(239): Contao\Form->compile()
#6 system/modules/core/forms/Form.php(84): Contao\Hybrid->generate()
#7 system/modules/core/library/Contao/Controller.php(484): Contao\Form->generate()
#8 system/modules/core/modules/ModuleArticle.php(213): Contao\Controller::getContentElement(Object(Contao\ContentModel), 'main')
#9 system/modules/core/modules/Module.php(287): Contao\ModuleArticle->compile()
#10 system/modules/core/modules/ModuleArticle.php(67): Contao\Module->generate()
#11 system/modules/core/library/Contao/Controller.php(417): Contao\ModuleArticle->generate(false)
#12 system/modules/core/library/Contao/Controller.php(277): Contao\Controller::getArticle(Object(Contao\ArticleModel), false, false, 'main')
#13 system/modules/core/pages/PageRegular.php(133): Contao\Controller::getFrontendModule('0', 'main')
#14 system/modules/core/controllers/FrontendIndex.php(285): Contao\PageRegular->generate(Object(Contao\PageModel), true)
#15 index.php(20): Contao\FrontendIndex->run()
#16 {main}
```
Since the `dateFormat` (and `timeFormat` and `datimFormat`) setting of the website root can be basically anything, Contao does not rely on that setting for validating date, time and datim input fields. Instead, it uses the functions `\Date::getNumericDateFormat()`, `\Date::getNumericTimeFormat()` and `\Date::getNumericDatimFormat()`. See [Validator.php#L108-L144](https://github.com/contao/core/blob/3.5.27/system/modules/core/library/Contao/Validator.php#L108-L144) (used in [Widget.php#L978-L1024](https://github.com/contao/core/blob/3.5.27/system/modules/core/library/Contao/Widget.php#L978-L1024)).

This PR also uses these functions instead.