### PR TITLE
YesNoTransformer should also support string values instead of hard check against 1 or 0.

### DIFF
--- a/library/Leads/DataTransformer/YesNoTransformer.php
+++ b/library/Leads/DataTransformer/YesNoTransformer.php
@@ -25,10 +25,14 @@ class YesNoTransformer implements DataTransformerInterface
      */
     public function transform($value)
     {
-        if ($value == '1') {
+        if (is_numeric($value) && $value == '1') {
 
             return $GLOBALS['TL_LANG']['MSC']['yes'];
         }
+	else if(!is_numeric($value) && $value != ''){
+
+            return $GLOBALS['TL_LANG']['MSC']['yes'];
+	}
 
         return $GLOBALS['TL_LANG']['MSC']['no'];
     }


### PR DESCRIPTION
Currently yes no transformer wont work with string value as shown below in the screenshot. If not, the exporter will mark all values of this field as 'no'.

![leads-yesno](https://user-images.githubusercontent.com/480054/33553853-c0c9b10c-d8fa-11e7-861e-b62790dc98d4.png)
