### PR TITLE
Add the drag and drop functionality to the field export configuration

### DIFF
--- a/dca/tl_lead_export.php
+++ b/dca/tl_lead_export.php
@@ -246,7 +246,7 @@ $GLOBALS['TL_DCA']['tl_lead_export'] = array
             'label'                   => &$GLOBALS['TL_LANG']['tl_lead_export']['fields'],
             'exclude'                 => true,
             'inputType'               => 'multiColumnWizard',
-            'eval'                    => array('mandatory'=>true, 'columnFields'=>array
+            'eval'                    => array('mandatory'=>true, 'dragAndDrop' => true, 'columnFields'=>array
             (
                 'column_display' => array
                 (


### PR DESCRIPTION
If there are many fields in the export, it can be awkward to sort them.
The drag and drop functionality from the MultiColumnWizard can improve with this:

![image](https://user-images.githubusercontent.com/6831223/35141649-e133b4ae-fcfb-11e7-8d02-86aaee024a87.png)
