### PR TITLE
Make overwriting of class DataCollector possible

### DIFF
--- a/library/Leads/Exporter/AbstractExporter.php
+++ b/library/Leads/Exporter/AbstractExporter.php
@@ -47,7 +47,7 @@ abstract class AbstractExporter implements ExporterInterface
      */
     protected function prepareDefaultDataCollector($config, $ids = null)
     {
-        $dataCollector = new DataCollector($config->master);
+        $dataCollector = new \DataCollector($config->master);
 
         // Limit the fields
         if ('fields' === $config->export) {


### PR DESCRIPTION
I wanted to use some custom logic inside my own class DataCollector inside my module. Without the suggested slash, my class DataCollector is not load, it always load class DataCollector from `system/modules/leads/library/Leads/DataCollector.php`. Can you please change this or am I doing this wrong?