### PR TITLE
Fix wrong header value assignments

### DIFF
--- a/library/Leads/Exporter/AbstractExporter.php
+++ b/library/Leads/Exporter/AbstractExporter.php
@@ -11,6 +11,7 @@
 namespace Leads\Exporter;
 
 
+use Contao\FormFieldModel;
 use Leads\DataCollector;
 use Leads\Leads;
 
@@ -125,7 +126,9 @@ abstract class AbstractExporter implements ExporterInterface
                     if (isset($dataHeaderFields[$column['field']])) {
                         $headerFields[] = $dataHeaderFields[$column['field']];
                     } else {
-                        $headerFields[] = '';
+                        // Field does not have data. Try to get label from database configuration
+                        $formField = FormFieldModel::findByPk($column['field']);
+                        $headerFields[] = $formField ? $formField->label : '';
                     }
                 }
             }
@@ -196,8 +199,9 @@ abstract class AbstractExporter implements ExporterInterface
 
             } else {
 
-                // Skip non existing fields
+                // Field does not have any data. Field seems got added later
                 if (!isset($fieldsData[$column['field']])) {
+                    $columnConfig[] = $column;
                     continue;
                 }
 


### PR DESCRIPTION
The current implementation of the data export might produce invalid header value assignments. It happens for following scenario:

1. The lead data export is configured with a custom export (`fields`)
2. The form fields changed after first data sets were stored (New fields are added)
3. There is no lead containing the new form fields

To avoid the issue this PR does two things:

- Retrieve the label from the database for fields having no data (and no custom label)
- Does not skip columns without data

This PR threats the configured export fields as the determining configuration. Having an invisible field configured in the export configuration might be a valid use case if older records does contain the data for such fields.