### PR TITLE
Fix icon for backend menu

### DIFF
--- a/src/Resources/public/leads.css
+++ b/src/Resources/public/leads.css
@@ -1,4 +1,4 @@
-#tl_navigation .tl_level_1_group .group-leads {
+nav[id=tl_navigation] .group-leads {
     background: url(/bundles/terminal42leads/images/inbox.d7392920.svg) 3px 2px no-repeat;
     background-size: 14px 14px;
 }


### PR DESCRIPTION
Fix the css for the back end icon.
I was not sure how it's correctly compiled via webpack - because I got a completly different output while running `npm run prod`