### PR TITLE
Load form object by model due to problems if $dc->id is null

### DIFF
--- a/dca/tl_form.php
+++ b/dca/tl_form.php
@@ -120,9 +120,9 @@ class tl_form_lead extends Backend
     public function modifyPalette($dc)
     {
         $strPalette = 'leadEnabled';
-        $objForm = \Database::getInstance()->execute("SELECT * FROM tl_form WHERE id=" . (int) $dc->id);
+        $objForm = \Contao\FormModel::findByPk($dc->id);
 
-        if ($objForm->leadEnabled) {
+        if ($objForm && $objForm->leadEnabled) {
             $strPalette .= ',leadMaster';
 
             if ($objForm->leadMaster == 0) {


### PR DESCRIPTION
I got an exception in my setup when the `modifyPalette`-method has been called without a valid `$dc->id` (for some reasons it was `null`). So I changed the objForm Loading to use the belonging FormModel.