### PR TITLE
Remove internal ModuleConfig

### DIFF
--- a/src/ContaoManager/Plugin.php
+++ b/src/ContaoManager/Plugin.php
@@ -16,7 +16,6 @@ namespace Terminal42\LeadsBundle\ContaoManager;
 use Contao\CoreBundle\ContaoCoreBundle;
 use Contao\ManagerPlugin\Bundle\BundlePluginInterface;
 use Contao\ManagerPlugin\Bundle\Config\BundleConfig;
-use Contao\ManagerPlugin\Bundle\Config\ModuleConfig;
 use Contao\ManagerPlugin\Bundle\Parser\ParserInterface;
 use Contao\ManagerPlugin\Routing\RoutingPluginInterface;
 use Symfony\Component\Config\Loader\LoaderResolverInterface;
@@ -34,8 +33,6 @@ class Plugin implements BundlePluginInterface, RoutingPluginInterface
             (new BundleConfig(Terminal42LeadsBundle::class))
                 ->setReplace(['leads'])
                 ->setLoadAfter([ContaoCoreBundle::class, 'haste', 'multicolumnwizard']),
-            new ModuleConfig('haste'),
-            new ModuleConfig('multicolumnwizard'),
         ];
     }
 


### PR DESCRIPTION
The `ModuleConfig` should not be used in a extension - see: https://github.com/contao/manager-plugin/pull/34

I know this is the develop branch - but unfortunately our LeadsPurger was only realized in the develop version, which we now use in a project.