### PR TITLE
Fix requirements for route terminal42_leads.export

### DIFF
--- a/src/Controller/Backend/LeadExportController.php
+++ b/src/Controller/Backend/LeadExportController.php
@@ -37,7 +37,7 @@ class LeadExportController
     }
 
     /**
-     * @Route("/contao/lead/export/{id}", name="terminal42_leads.export", requirements={"id"="\d"}, defaults={"_scope"="backend"})
+     * @Route("/contao/lead/export/{id}", name="terminal42_leads.export", requirements={"id"="\d+"}, defaults={"_scope"="backend"})
      */
     public function __invoke(int $id): void
     {

--- a/src/EventListener/DataContainer/LeadExportOperationListener.php
+++ b/src/EventListener/DataContainer/LeadExportOperationListener.php
@@ -51,7 +51,7 @@ class LeadExportOperationListener
                 'button_callback' => function ($href, $label, $title, $class, $attributes) use ($config) {
                     return sprintf(
                         '<a href="%s" class="%s" title="%s"%s>%s</a> ',
-                        $this->router->generate('terminal42_leads.export', ['id' => $config->id]),
+                        $this->router->generate('terminal42_leads.export', ['id' => (int)$config->id]),
                         $class,
                         specialchars($title),
                         $attributes,


### PR DESCRIPTION
The route terminal42_leads.export is not generated if you have export IDs greater than 9!

I know this is the develop branch - but unfortunately our LeadsPurger was only realized in the develop version, which we now use in a project.