### PR TITLE
Unlock PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "source": "https://github.com/terminal42/contao-leads"
     },
     "require": {
-        "php": "^5.3.2 || ^7.0",
+        "php": "^5.3.2 || ^7.0 || ^8.0",
         "contao/core-bundle": "^3.5.1 || ^4.1",
         "contao-community-alliance/composer-plugin": "^2.4.0 || 3.*",
         "codefog/contao-haste": "^4.10.0",


### PR DESCRIPTION
A quick test in my dev environment did not show any problems with php 8.
EDIT: the unlock should also be merged or picked to the develop branch!