### PR TITLE
Refactor deprecated contao methods/classes

### DIFF
--- a/src/Command/ExportCommand.php
+++ b/src/Command/ExportCommand.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\Command;
 
-use Contao\CoreBundle\Framework\ContaoFrameworkInterface;
+use Contao\CoreBundle\Framework\ContaoFramework;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\InvalidArgumentException;
@@ -28,7 +28,7 @@ use Terminal42\LeadsBundle\Exporter\ExporterFactory;
 class ExportCommand extends Command
 {
     /**
-     * @var ContaoFrameworkInterface
+     * @var ContaoFramework
      */
     private $framework;
 
@@ -47,7 +47,7 @@ class ExportCommand extends Command
      */
     private $filesystem;
 
-    public function __construct(ContaoFrameworkInterface $framework, Connection $db, ExporterFactory $exportFactory, Filesystem $filesystem = null)
+    public function __construct(ContaoFramework $framework, Connection $db, ExporterFactory $exportFactory, Filesystem $filesystem = null)
     {
         $this->framework = $framework;
         $this->db = $db;
@@ -289,9 +289,9 @@ class ExportCommand extends Command
     {
         $configs = [];
         $rows = $this->db->fetchAll("
-            SELECT id, name, (SELECT title FROM tl_form WHERE tl_form.id=tl_lead_export.pid) AS form 
-            FROM tl_lead_export 
-            WHERE cliExport='1' 
+            SELECT id, name, (SELECT title FROM tl_form WHERE tl_form.id=tl_lead_export.pid) AS form
+            FROM tl_lead_export
+            WHERE cliExport='1'
             ORDER BY name
         ");
 

--- a/src/Controller/Backend/LeadDetailsController.php
+++ b/src/Controller/Backend/LeadDetailsController.php
@@ -19,6 +19,7 @@ namespace Terminal42\LeadsBundle\Controller\Backend;
 
 use Contao\CoreBundle\Framework\ContaoFramework;
 use Contao\Database;
+use Contao\StringUtil;
 use Contao\System;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -142,11 +143,11 @@ class LeadDetailsController
 
     private function formatLabel($row): string
     {
-        $strValue = implode(', ', deserialize($row->value, true));
+        $strValue = implode(', ', StringUtil::deserialize($row->value, true));
 
         if (!empty($row->label) && $row->label !== $row->value) {
             $strLabel = $row->label;
-            $arrLabel = deserialize($row->label, true);
+            $arrLabel = StringUtil::deserialize($row->label, true);
 
             if (!empty($arrLabel)) {
                 $strLabel = implode(', ', $arrLabel);
@@ -164,6 +165,6 @@ class LeadDetailsController
             return null;
         }
 
-        return implode(', ', deserialize($row->value, true));
+        return implode(', ', StringUtil::deserialize($row->value, true));
     }
 }

--- a/src/Controller/Backend/LeadNotificationController.php
+++ b/src/Controller/Backend/LeadNotificationController.php
@@ -18,6 +18,7 @@ use Contao\Environment;
 use Contao\FormModel;
 use Contao\Input;
 use Contao\Message;
+use Contao\StringUtil;
 use Contao\System;
 use NotificationCenter\Model\Notification;
 use Terminal42\LeadsBundle\Util\NotificationCenter;
@@ -104,7 +105,7 @@ class LeadNotificationController
 
         $return = '
 <div id="tl_buttons">
-<a href="'.System::getReferer(true).'" class="header_back" title="'.specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']).'" accesskey="b">'.$GLOBALS['TL_LANG']['MSC']['backBT'].'</a>
+<a href="'.System::getReferer(true).'" class="header_back" title="'.StringUtil::specialchars($GLOBALS['TL_LANG']['MSC']['backBTTitle']).'" accesskey="b">'.$GLOBALS['TL_LANG']['MSC']['backBT'].'</a>
 </div>
 
 <div class="leads-notification-center">
@@ -137,7 +138,7 @@ class LeadNotificationController
 <div class="tl_formbody_submit">
 
 <div class="tl_submit_container">
-  <input type="submit" name="save" id="save" class="tl_submit" accesskey="s" value="'.specialchars($GLOBALS['TL_LANG']['tl_lead']['notification'][0]).'">
+  <input type="submit" name="save" id="save" class="tl_submit" accesskey="s" value="'.StringUtil::specialchars($GLOBALS['TL_LANG']['tl_lead']['notification'][0]).'">
 </div>
 
 </div>

--- a/src/DataCollector.php
+++ b/src/DataCollector.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle;
 
+use Contao\StringUtil;
+
 class DataCollector
 {
     /**
@@ -307,7 +309,7 @@ class DataCollector
                 && 'checkbox' === $row['type']
                 && '' !== $row['options']
             ) {
-                $options = deserialize($row['options'], true);
+                $options = StringUtil::deserialize($row['options'], true);
 
                 if (1 === \count($options)) {
                     $headerFields[$fieldId] = $options[0]['label'];

--- a/src/EventListener/DataContainer/FormListener.php
+++ b/src/EventListener/DataContainer/FormListener.php
@@ -15,6 +15,7 @@ namespace Terminal42\LeadsBundle\EventListener\DataContainer;
 
 use Contao\CoreBundle\DataContainer\PaletteManipulator;
 use Contao\DataContainer;
+use Contao\StringUtil;
 
 class FormListener
 {
@@ -56,7 +57,7 @@ class FormListener
         $fieldsMapper = array_combine($oldFormFields->fetchEach('id'), $newFormFields->fetchEach('id'));
 
         while ($exports->next()) {
-            $fields = deserialize($exports->fields, true);
+            $fields = StringUtil::deserialize($exports->fields, true);
 
             // Map the fields
             foreach ($fields as $k => $v) {

--- a/src/EventListener/DataContainer/LeadDataListener.php
+++ b/src/EventListener/DataContainer/LeadDataListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Terminal42\LeadsBundle\EventListener\DataContainer;
 
 use Contao\Controller;
+use Contao\StringUtil;
 use Contao\System;
 
 class LeadDataListener
@@ -29,7 +30,7 @@ class LeadDataListener
             return;
         }
 
-        $objUser->forms = deserialize($objUser->forms);
+        $objUser->forms = StringUtil::deserialize($objUser->forms);
 
         if (!\is_array($objUser->forms) || empty($objUser->forms)) {
             System::log('Not enough permissions to access leads data ID "'.\Input::get('id').'"', __METHOD__, TL_ERROR);
@@ -57,8 +58,8 @@ class LeadDataListener
      */
     public function onChildRecordCallback($row)
     {
-        $label = implode(', ', deserialize($row['label'], true));
-        $value = implode(', ', deserialize($row['value'], true));
+        $label = implode(', ', StringUtil::deserialize($row['label'], true));
+        $value = implode(', ', StringUtil::deserialize($row['value'], true));
 
         if ($label === $value) {
             $value = '';

--- a/src/EventListener/DataContainer/LeadExportListener.php
+++ b/src/EventListener/DataContainer/LeadExportListener.php
@@ -17,6 +17,7 @@ use Contao\Controller;
 use Contao\Database;
 use Contao\DataContainer;
 use Contao\Input;
+use Contao\StringUtil;
 use Contao\System;
 use Terminal42\LeadsBundle\DataTransformer\DataTransformerFactory;
 use Terminal42\LeadsBundle\Exporter\ExporterFactory;
@@ -92,7 +93,7 @@ class LeadExportListener
      */
     public function onFieldsLoadCallback($varValue, $dc = null)
     {
-        $arrFields = deserialize($varValue, true);
+        $arrFields = StringUtil::deserialize($varValue, true);
 
         // Load the form fields
         if (empty($arrFields) && $dc->id) {

--- a/src/EventListener/DataContainer/LeadExportOperationListener.php
+++ b/src/EventListener/DataContainer/LeadExportOperationListener.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Terminal42\LeadsBundle\EventListener\DataContainer;
 
 use Contao\Input;
+use Contao\StringUtil;
 use Symfony\Component\Routing\RouterInterface;
 use Terminal42\LeadsBundle\Model\LeadExport;
 
@@ -53,7 +54,7 @@ class LeadExportOperationListener
                         '<a href="%s" class="%s" title="%s"%s>%s</a> ',
                         $this->router->generate('terminal42_leads.export', ['id' => (int)$config->id]),
                         $class,
-                        specialchars($title),
+                        StringUtil::specialchars($title),
                         $attributes,
                         $label
                     );

--- a/src/EventListener/DataContainer/LeadListener.php
+++ b/src/EventListener/DataContainer/LeadListener.php
@@ -115,7 +115,7 @@ class LeadListener
             return '';
         }
 
-        return '<a href="contao/main.php?do=form&amp;table=tl_lead_export&amp;id='.Input::get('master').'" class="'.$class.'" title="'.specialchars($title).'"'.$attributes.'>'.$label.'</a> ';
+        return '<a href="contao/main.php?do=form&amp;table=tl_lead_export&amp;id='.Input::get('master').'" class="'.$class.'" title="'.\Contao\StringUtil::specialchars($title).'"'.$attributes.'>'.$label.'</a> ';
     }
 
     public function onShowButtonCallback(array $row, $href, $label, $title, $icon, $attributes, $table)
@@ -168,12 +168,12 @@ class LeadListener
 
         // Generate buttons
         foreach ($arrConfigs as $config) {
-            $arrButtons['export_'.$config['id']] = '<input type="submit" name="export_'.$config['id'].'" id="export_'.$config['id'].'" class="tl_submit" value="'.specialchars($GLOBALS['TL_LANG']['tl_lead']['export'][0].' "'.$config['name'].'"').'">';
+            $arrButtons['export_'.$config['id']] = '<input type="submit" name="export_'.$config['id'].'" id="export_'.$config['id'].'" class="tl_submit" value="'.\Contao\StringUtil::specialchars($GLOBALS['TL_LANG']['tl_lead']['export'][0].' "'.$config['name'].'"').'">';
         }
 
         // Notification Center integration
         if ($this->notificationCenter->isAvailable()) {
-            $arrButtons['notification'] = '<input type="submit" name="notification" id="notification" class="tl_submit" value="'.specialchars($GLOBALS['TL_LANG']['tl_lead']['notification'][0]).'">';
+            $arrButtons['notification'] = '<input type="submit" name="notification" id="notification" class="tl_submit" value="'.\Contao\StringUtil::specialchars($GLOBALS['TL_LANG']['tl_lead']['notification'][0]).'">';
         }
 
         return $arrButtons;

--- a/src/EventListener/DataContainer/LeadListener.php
+++ b/src/EventListener/DataContainer/LeadListener.php
@@ -90,7 +90,7 @@ class LeadListener
         $objData = \Database::getInstance()->prepare('SELECT * FROM tl_lead_data WHERE pid=?')->execute($row['id']);
 
         while ($objData->next()) {
-            StringUtil::flatten(deserialize($objData->value), $objData->name, $arrTokens);
+            StringUtil::flatten(StringUtil::deserialize($objData->value), $objData->name, $arrTokens);
         }
 
         return StringUtil::recursiveReplaceTokensAndTags($objForm->leadLabel, $arrTokens);

--- a/src/EventListener/FormDataListener.php
+++ b/src/EventListener/FormDataListener.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\EventListener;
 
+use Contao\StringUtil;
 use Contao\System;
 
 class FormDataListener
@@ -168,7 +169,7 @@ class FormDataListener
         $varValue = $this->convertRgxp($varValue, $objField->rgxp);
 
         if (!empty($objField->options)) {
-            $arrOptions = deserialize($objField->options, true);
+            $arrOptions = StringUtil::deserialize($objField->options, true);
 
             foreach ($arrOptions as $arrOption) {
                 if ($arrOption['value'] === $varValue && '' !== $arrOption['label']) {

--- a/src/EventListener/TokenRowListener.php
+++ b/src/EventListener/TokenRowListener.php
@@ -46,7 +46,7 @@ class TokenRowListener
 
             if (isset($data[$fieldConfig['id']])) {
                 $value = $data[$fieldConfig['id']]['value'];
-                $value = deserialize($value);
+                $value = \Contao\StringUtil::deserialize($value);
 
                 // Add multiple tokens (<fieldname>_<option_name>) for multi-choice fields
                 if (\is_array($value)) {

--- a/src/EventListener/UserNavigationListener.php
+++ b/src/EventListener/UserNavigationListener.php
@@ -15,6 +15,7 @@ namespace Terminal42\LeadsBundle\EventListener;
 
 use Contao\BackendUser;
 use Contao\Input;
+use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
@@ -76,7 +77,7 @@ class UserNavigationListener
 
         foreach ($forms as $form) {
             $modules['leads']['modules']['lead_'. $form['id']] = [
-                'title'     => specialchars(sprintf($GLOBALS['TL_LANG']['MOD']['leads'][1], $form['title'])),
+                'title'     => StringUtil::specialchars(sprintf($GLOBALS['TL_LANG']['MOD']['leads'][1], $form['title'])),
                 'label'     => $form['leadMenuLabel'] ?: $form['title'],
                 'class'     => 'navigation leads',
                 'href'      => 'contao/main.php?do=lead&master='.$form['id'],

--- a/src/Exporter/AbstractExporter.php
+++ b/src/Exporter/AbstractExporter.php
@@ -248,7 +248,7 @@ abstract class AbstractExporter implements ExporterInterface
             && 'checkbox' === $fieldConfig['type']
             && '' !== $fieldConfig['options']
         ) {
-            $options = deserialize($fieldConfig['options'], true);
+            $options = \Contao\StringUtil::deserialize($fieldConfig['options'], true);
 
             if (1 === \count($options)) {
                 $fieldConfig['transformers'] = array_merge(

--- a/src/Exporter/ExporterFactory.php
+++ b/src/Exporter/ExporterFactory.php
@@ -82,8 +82,8 @@ class ExporterFactory
         $config = $result->fetch(FetchMode::STANDARD_OBJECT);
 
         $config->master = $config->master ?: $config->pid;
-        $config->fields = deserialize($config->fields, true);
-        $config->tokenFields = deserialize($config->tokenFields, true);
+        $config->fields = \Contao\StringUtil::deserialize($config->fields, true);
+        $config->tokenFields = \Contao\StringUtil::deserialize($config->tokenFields, true);
 
         return $config;
     }

--- a/src/Util/DataTransformer.php
+++ b/src/Util/DataTransformer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\Util;
 
+use Contao\StringUtil;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Terminal42\LeadsBundle\DataTransformer\DataTransformerFactory;
 use Terminal42\LeadsBundle\Event\TransformRowEvent;
@@ -83,7 +84,7 @@ class DataTransformer
      */
     public function transformValue($value, array $columnConfig)
     {
-        $value = implode(', ', deserialize($value, true));
+        $value = implode(', ', StringUtil::deserialize($value, true));
 
         // Merge transformers chosen by user (format) with an array of arbitrary ones
         // defined by any developer.
@@ -149,7 +150,7 @@ class DataTransformer
     private function prepareLabel($label)
     {
         if (!empty($label)) {
-            $labelChunks = deserialize($label);
+            $labelChunks = StringUtil::deserialize($label);
 
             if (\is_array($labelChunks) && !empty($labelChunks)) {
                 $label = implode(', ', $label);


### PR DESCRIPTION
Refactor deprecated usages of contao methods/classes:
* deserialize
* specialchars
* ContaoFrameworkInterface