### PR TITLE
Support haste 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ and define the listing of the form data using simple tags.
 
 The leads extension additionally offers an export function for each Lead in the backend. You can 
 configure it as you wish! Export options for CSV and Excel are available. _However_ you need to 
-install `phpoffice/phpspreadsheet` package for Excel support, 
-otherwise the Excel export option will not be available. 
+install `phpoffice/phpspreadsheet` package for CSV and Excel support, 
+otherwise the CSV and Excel export option will not be available. 
 
 Simple Tokens
 -------------

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ and define the listing of the form data using simple tags.
 
 The leads extension additionally offers an export function for each Lead in the backend. You can 
 configure it as you wish! Export options for CSV and Excel are available. _However_ you need to 
-install either the `phpoffice/phpspreadsheet` or `phpoffice/phpexcel` package for Excel support, 
+install `phpoffice/phpspreadsheet` package for Excel support, 
 otherwise the Excel export option will not be available. 
 
 Simple Tokens

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "symfony/security-bundle": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
-        "phpoffice/phpexcel": "^1.8",
+        "phpoffice/phpspreadsheet": "^1.26",
         "terminal42/notification_center": "^1.7",
         "contao/manager-plugin": "^2.0"
     },
@@ -53,7 +53,7 @@
         "contao/manager-plugin": "<2.0 || >=3.0"
     },
     "suggest": {
-        "phpoffice/phpexcel": "To enable excel export of lead data.",
+        "phpoffice/phpspreadsheet": "To enable excel export of lead data.",
         "terminal42/notification_center": "Send notifications for leads."
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -66,5 +66,12 @@
     },
     "scripts": {
         "cs-fixer": "@php tools/ecs/vendor/bin/ecs check src/ --fix --ansi"
+    },
+    "config": {
+        "allow-plugins": {
+            "contao-components/installer": true,
+            "contao/manager-plugin": true,
+            "contao-community-alliance/composer-plugin": true
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "codefog/contao-haste": "^5.0",
         "contao/core-bundle": "^4.13 || ^5.0",
         "doctrine/dbal": "^2.11 || ^3.0",
-        "menatwork/contao-multicolumnwizard": "^3.3",
+        "menatwork/contao-multicolumnwizard-bundle": "^3.5",
         "symfony/config": "^4.4 || ^5.4 || ^6.0",
         "symfony/console": "^4.4 || ^5.4 || ^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
     },
     "require-dev": {
         "phpoffice/phpexcel": "^1.8",
-        "terminal42/notification_center": "dev-haste-5@dev",
+        "terminal42/notification_center": "^1.7",
         "contao/manager-plugin": "^2.0"
     },
     "conflict": {

--- a/config/controller.yml
+++ b/config/controller.yml
@@ -8,7 +8,7 @@ services:
 
     Terminal42\LeadsBundle\Controller\Backend\LeadNotificationController:
         public: true
-        arguments: ['@Terminal42\LeadsBundle\Util\NotificationCenter']
+        arguments: ['@Terminal42\LeadsBundle\Util\NotificationCenter', '@Codefog\HasteBundle\StringParser']
 
     Terminal42\LeadsBundle\Controller\Backend\LeadDetailsController:
         public: true

--- a/config/listener.yml
+++ b/config/listener.yml
@@ -14,7 +14,7 @@ services:
         tags: [{ name: kernel.event_listener, event: terminal42_leads.transform_row, method: onTransformRow, priority: 100 }]
 
     Terminal42\LeadsBundle\EventListener\TokenRowListener:
-        arguments: ['@Terminal42\LeadsBundle\Util\DataTransformer']
+        arguments: ['@Terminal42\LeadsBundle\Util\DataTransformer', '@Codefog\HasteBundle\StringParser']
         tags: [{ name: kernel.event_listener, event: terminal42_leads.transform_row, method: onTransformRow }]
 
     Terminal42\LeadsBundle\EventListener\DataContainer\LeadListener:
@@ -24,6 +24,7 @@ services:
             - '@Terminal42\LeadsBundle\Exporter\ExporterFactory'
             - '@router'
             - '@security.authorization_checker'
+            - '@Codefog\HasteBundle\StringParser'
 
     Terminal42\LeadsBundle\EventListener\DataContainer\LeadExportListener:
         public: true

--- a/src/Controller/Backend/LeadNotificationController.php
+++ b/src/Controller/Backend/LeadNotificationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\Controller\Backend;
 
+use Codefog\HasteBundle\StringParser;
 use Contao\Controller;
 use Contao\Database;
 use Contao\Environment;
@@ -17,14 +18,13 @@ use Terminal42\LeadsBundle\Util\NotificationCenter;
 
 class LeadNotificationController
 {
-    /**
-     * @var NotificationCenter
-     */
-    private $notificationCenter;
+    private NotificationCenter $notificationCenter;
+    private StringParser $stringParser;
 
-    public function __construct(NotificationCenter $notificationCenter)
+    public function __construct(NotificationCenter $notificationCenter, StringParser $stringParser)
     {
         $this->notificationCenter = $notificationCenter;
+        $this->stringParser = $stringParser;
     }
 
     public function __invoke()
@@ -203,13 +203,13 @@ class LeadNotificationController
         $arrTokens['raw_data'] = '';
 
         foreach ($arrData as $k => $v) {
-            \Haste\Util\StringUtil::flatten($v, 'form_'.$k, $arrTokens);
+            $this->stringParser->flatten($v, 'form_'.$k, $arrTokens);
             $arrTokens['formlabel_'.$k] = $arrLabels[$k] ?? ucfirst($k);
             $arrTokens['raw_data'] .= ($arrLabels[$k] ?? ucfirst($k)).': '.(\is_array($v) ? implode(', ', $v) : $v)."\n";
         }
 
         foreach ($arrForm as $k => $v) {
-            \Haste\Util\StringUtil::flatten($v, 'formconfig_'.$k, $arrTokens);
+            $this->stringParser->flatten($v, 'formconfig_'.$k, $arrTokens);
         }
 
         // Administrator e-mail

--- a/src/Controller/Backend/LeadNotificationController.php
+++ b/src/Controller/Backend/LeadNotificationController.php
@@ -29,7 +29,7 @@ class LeadNotificationController
 
     public function __invoke()
     {
-        if (\Input::get('master') || !$this->notificationCenter->isAvailable()) {
+        if (Input::get('master') || !$this->notificationCenter->isAvailable()) {
             // TODO show exception message in the backend
             Controller::redirect('contao/main.php?act=error');
         }
@@ -50,20 +50,20 @@ class LeadNotificationController
         // Process the form
         if ('tl_leads_notification' === Input::post('FORM_SUBMIT')) {
             /**
-             * @var \FormModel
+             * @var FormModel
              * @var Notification $notification
              */
             if (
                 !isset($notifications[Input::post('notification')])
-                || !\is_array(\Input::post('IDS'))
-                || null === ($form = \FormModel::findByPk(\Input::get('master')))
-                || null === ($notification = Notification::findByPk(\Input::post('notification')))
+                || !\is_array(Input::post('IDS'))
+                || null === ($form = FormModel::findByPk(Input::get('master')))
+                || null === ($notification = Notification::findByPk(Input::post('notification')))
             ) {
                 Controller::reload();
             }
 
-            if (\Input::get('id')) {
-                $ids = [(int) \Input::get('id')];
+            if (Input::get('id')) {
+                $ids = [(int) Input::get('id')];
             } else {
                 $request = System::getContainer()->get('request_stack')->getCurrentRequest();
 
@@ -90,10 +90,10 @@ class LeadNotificationController
                 }
             }
 
-            Controller::redirect(\System::getReferer());
+            Controller::redirect(System::getReferer());
         }
 
-        return $this->generateForm($notifications, [\Input::get('id')]);
+        return $this->generateForm($notifications, [Input::get('id')]);
     }
 
     /**
@@ -116,8 +116,8 @@ class LeadNotificationController
 
 <div class="leads-notification-center">
 <h2 class="sub_headline">'.$GLOBALS['TL_LANG']['tl_lead']['notification'][0].'</h2>
-'.\Message::generate().'
-<form action="'.ampersand(Environment::get('request'), true).'" id="tl_leads_notification" class="tl_form" method="post">
+'.Message::generate().'
+<form action="'.StringUtil::ampersand(Environment::get('request'), true).'" id="tl_leads_notification" class="tl_form" method="post">
 <div class="tl_formbody_edit">
 <input type="hidden" name="FORM_SUBMIT" value="tl_leads_notification">
 <input type="hidden" name="REQUEST_TOKEN" value="'.REQUEST_TOKEN.'">

--- a/src/EventListener/DataContainer/LeadExportListener.php
+++ b/src/EventListener/DataContainer/LeadExportListener.php
@@ -198,7 +198,7 @@ class LeadExportListener
     /**
      * Loads JS.
      */
-    private function loadJs()
+    private function loadJs(): void
     {
         $GLOBALS['TL_JAVASCRIPT'][] = $GLOBALS['BE_MOD']['leads']['lead']['javascript'];
     }

--- a/src/EventListener/DataContainer/LeadListener.php
+++ b/src/EventListener/DataContainer/LeadListener.php
@@ -135,7 +135,7 @@ class LeadListener
     {
         $arrConfigs = Database::getInstance()
             ->prepare('SELECT id, name FROM tl_lead_export WHERE pid=? ORDER BY name')
-            ->execute(\Input::get('master'))
+            ->execute(Input::get('master'))
             ->fetchAllAssoc()
         ;
 
@@ -147,7 +147,7 @@ class LeadListener
                 Controller::reload();
             }
 
-            if (\Input::post('notification')) {
+            if (Input::post('notification')) {
                 Controller::redirect(Backend::addToUrl('key=notification'));
             }
 

--- a/src/EventListener/DataContainer/LeadListener.php
+++ b/src/EventListener/DataContainer/LeadListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\EventListener\DataContainer;
 
+use Codefog\HasteBundle\StringParser;
 use Contao\Backend;
 use Contao\BackendUser;
 use Contao\Controller;
@@ -11,8 +12,8 @@ use Contao\Database;
 use Contao\Date;
 use Contao\Image;
 use Contao\Input;
+use Contao\StringUtil;
 use Contao\System;
-use Haste\Util\StringUtil;
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
@@ -21,32 +22,19 @@ use Terminal42\LeadsBundle\Util\NotificationCenter;
 
 class LeadListener
 {
-    /**
-     * @var NotificationCenter
-     */
-    private $notificationCenter;
+    private NotificationCenter $notificationCenter;
+    private ExporterFactory $exportFactory;
+    private RouterInterface $router;
+    private AuthorizationCheckerInterface $authorizationChecker;
+    private StringParser $stringParser;
 
-    /**
-     * @var ExporterFactory
-     */
-    private $exportFactory;
-
-    /**
-     * @var RouterInterface
-     */
-    private $router;
-
-    /**
-     * @var AuthorizationCheckerInterface
-     */
-    private $authorizationChecker;
-
-    public function __construct(NotificationCenter $notificationCenter, ExporterFactory $exportFactory, RouterInterface $router, AuthorizationCheckerInterface $authorizationChecker)
+    public function __construct(NotificationCenter $notificationCenter, ExporterFactory $exportFactory, RouterInterface $router, AuthorizationCheckerInterface $authorizationChecker, StringParser $stringParser)
     {
         $this->notificationCenter = $notificationCenter;
         $this->exportFactory = $exportFactory;
         $this->router = $router;
         $this->authorizationChecker = $authorizationChecker;
+        $this->stringParser = $stringParser;
     }
 
     public function onLoadCallback(): void
@@ -86,10 +74,10 @@ class LeadListener
         $objData = Database::getInstance()->prepare('SELECT * FROM tl_lead_data WHERE pid=?')->execute($row['id']);
 
         while ($objData->next()) {
-            StringUtil::flatten(\Contao\StringUtil::deserialize($objData->value), $objData->name, $arrTokens);
+            $this->stringParser->flatten(StringUtil::deserialize($objData->value), $objData->name, $arrTokens);
         }
 
-        return StringUtil::recursiveReplaceTokensAndTags($objForm->leadLabel, $arrTokens);
+        return $this->stringParser->recursiveReplaceTokensAndTags($objForm->leadLabel, $arrTokens);
     }
 
     /**
@@ -111,7 +99,7 @@ class LeadListener
             return '';
         }
 
-        return '<a href="contao/main.php?do=form&amp;table=tl_lead_export&amp;id='.Input::get('master').'" class="'.$class.'" title="'.\Contao\StringUtil::specialchars($title).'"'.$attributes.'>'.$label.'</a> ';
+        return '<a href="contao/main.php?do=form&amp;table=tl_lead_export&amp;id='.Input::get('master').'" class="'.$class.'" title="'.StringUtil::specialchars($title).'"'.$attributes.'>'.$label.'</a> ';
     }
 
     public function onShowButtonCallback(array $row, $href, $label, $title, $icon, $attributes, $table)
@@ -119,8 +107,8 @@ class LeadListener
         return sprintf(
             '<a href="%s" title="%s" onclick="Backend.openModalIframe({\'title\':\'%s\',\'url\':this.href});return false"%s>%s</a> ',
             $this->router->generate('terminal42_leads.details', ['id' => $row['id'], 'popup' => 1]),
-            \Contao\StringUtil::specialchars($title),
-            \Contao\StringUtil::specialchars(str_replace("'", "\\'", sprintf($GLOBALS['TL_LANG'][$table]['show'][1], $row['id']))),
+            StringUtil::specialchars($title),
+            StringUtil::specialchars(str_replace("'", "\\'", sprintf($GLOBALS['TL_LANG'][$table]['show'][1], $row['id']))),
             $attributes,
             Image::getHtml($icon, $label)
         );
@@ -164,12 +152,12 @@ class LeadListener
 
         // Generate buttons
         foreach ($arrConfigs as $config) {
-            $arrButtons['export_'.$config['id']] = '<input type="submit" name="export_'.$config['id'].'" id="export_'.$config['id'].'" class="tl_submit" value="'.\Contao\StringUtil::specialchars($GLOBALS['TL_LANG']['tl_lead']['export'][0].' "'.$config['name'].'"').'">';
+            $arrButtons['export_'.$config['id']] = '<input type="submit" name="export_'.$config['id'].'" id="export_'.$config['id'].'" class="tl_submit" value="'.StringUtil::specialchars($GLOBALS['TL_LANG']['tl_lead']['export'][0].' "'.$config['name'].'"').'">';
         }
 
         // Notification Center integration
         if ($this->notificationCenter->isAvailable()) {
-            $arrButtons['notification'] = '<input type="submit" name="notification" id="notification" class="tl_submit" value="'.\Contao\StringUtil::specialchars($GLOBALS['TL_LANG']['tl_lead']['notification'][0]).'">';
+            $arrButtons['notification'] = '<input type="submit" name="notification" id="notification" class="tl_submit" value="'.StringUtil::specialchars($GLOBALS['TL_LANG']['tl_lead']['notification'][0]).'">';
         }
 
         return $arrButtons;

--- a/src/EventListener/TokenRowListener.php
+++ b/src/EventListener/TokenRowListener.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\EventListener;
 
-use Haste\Util\StringUtil;
+use Codefog\HasteBundle\StringParser;
+use Contao\StringUtil;
 use Terminal42\LeadsBundle\Event\TransformRowEvent;
 use Terminal42\LeadsBundle\Util\DataTransformer;
 
 class TokenRowListener
 {
-    /**
-     * @var DataTransformer
-     */
-    private $dataTransformer;
+    private DataTransformer $dataTransformer;
+    private StringParser $stringParser;
 
-    public function __construct(DataTransformer $dataTransformer)
+    public function __construct(DataTransformer $dataTransformer, StringParser $stringParser)
     {
         $this->dataTransformer = $dataTransformer;
+        $this->stringParser = $stringParser;
     }
 
     public function onTransformRow(TransformRowEvent $event): void
@@ -37,7 +37,7 @@ class TokenRowListener
 
             if (isset($data[$fieldConfig['id']])) {
                 $value = $data[$fieldConfig['id']]['value'];
-                $value = \Contao\StringUtil::deserialize($value);
+                $value = StringUtil::deserialize($value);
 
                 // Add multiple tokens (<fieldname>_<option_name>) for multi-choice fields
                 if (\is_array($value)) {
@@ -52,6 +52,6 @@ class TokenRowListener
             $tokens[$fieldConfig['name']] = $value;
         }
 
-        $event->setValue(StringUtil::recursiveReplaceTokensAndTags($columnConfig['tokensValue'], $tokens));
+        $event->setValue($this->stringParser->recursiveReplaceTokensAndTags($columnConfig['tokensValue'], $tokens));
     }
 }

--- a/src/Exporter/AbstractExcelExporter.php
+++ b/src/Exporter/AbstractExcelExporter.php
@@ -15,11 +15,11 @@ namespace Terminal42\LeadsBundle\Exporter;
 
 use Contao\Files;
 use Contao\FilesModel;
-use Haste\Http\Response\Response;
 use Haste\IO\Reader\ArrayReader;
 use Haste\IO\Writer\ExcelFileWriter;
 use PHPExcel_Cell;
 use PHPExcel_IOFactory;
+use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractExcelExporter extends AbstractExporter
 {

--- a/src/Exporter/AbstractExcelExporter.php
+++ b/src/Exporter/AbstractExcelExporter.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\Exporter;
 
+use Contao\Database\Result;
+use Contao\File;
 use Contao\Files;
 use Contao\FilesModel;
 use Haste\IO\Reader\ArrayReader;
 use Haste\IO\Writer\ExcelFileWriter;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use Symfony\Component\HttpFoundation\Response;
@@ -36,11 +39,12 @@ abstract class AbstractExcelExporter extends AbstractExporter
     /**
      * Exports based on Excel format.
      *
-     * @param \Contao\Database\Result|object $config
-     * @param array|null              $ids
-     * @param string                  $format
+     * @param Result|object $config
+     * @param array|null $ids
+     * @param string $format
      *
-     * @return \Contao\File
+     * @return File
+     * @throws \Exception
      */
     protected function exportWithFormat($config, $ids, $format)
     {
@@ -67,9 +71,9 @@ abstract class AbstractExcelExporter extends AbstractExporter
      * @param $config
      * @param $format
      *
-     * @throws ExportFailedException
+     * @return File
+     * @throws ExportFailedException|\Exception
      *
-     * @return \Contao\File
      */
     protected function exportWithoutTemplate(
         $config,
@@ -93,7 +97,7 @@ abstract class AbstractExcelExporter extends AbstractExporter
 
         $this->updateLastRun($config);
 
-        return new \Contao\File($writer->getFilename());
+        return new File($writer->getFilename());
     }
 
     /**
@@ -102,7 +106,8 @@ abstract class AbstractExcelExporter extends AbstractExporter
      * @param $config
      * @param $format
      *
-     * @return \Contao\File
+     * @return File
+     * @throws Exception|\Exception
      */
     protected function exportWithTemplate(
         $config,
@@ -163,6 +168,6 @@ abstract class AbstractExcelExporter extends AbstractExporter
 
         $this->updateLastRun($config);
 
-        return new \Contao\File($tmpPath);
+        return new File($tmpPath);
     }
 }

--- a/src/Exporter/AbstractExcelExporter.php
+++ b/src/Exporter/AbstractExcelExporter.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\Exporter;
 
+use Contao\Files;
+use Contao\FilesModel;
 use Haste\Http\Response\Response;
 use Haste\IO\Reader\ArrayReader;
 use Haste\IO\Writer\ExcelFileWriter;
@@ -32,7 +34,7 @@ abstract class AbstractExcelExporter extends AbstractExporter
     /**
      * Exports based on Excel format.
      *
-     * @param \Database\Result|object $config
+     * @param \Contao\Database\Result|object $config
      * @param array|null              $ids
      * @param string                  $format
      *
@@ -107,7 +109,7 @@ abstract class AbstractExcelExporter extends AbstractExporter
         $format
     ) {
         // Fetch the template and make a copy of it
-        $template = \FilesModel::findByPk($config->template);
+        $template = FilesModel::findByPk($config->template);
 
         if (null === $template) {
             $objResponse = new Response('Could not find template.', 500);
@@ -115,7 +117,7 @@ abstract class AbstractExcelExporter extends AbstractExporter
         }
 
         $tmpPath = 'system/tmp/'.$this->exportFile->getFilenameForConfig($config);
-        \Files::getInstance()->copy($template->path, $tmpPath);
+        Files::getInstance()->copy($template->path, $tmpPath);
 
         $excelReader = PHPExcel_IOFactory::createReader($format);
         $excel = $excelReader->load(TL_ROOT.'/'.$tmpPath);

--- a/src/Exporter/AbstractExcelExporter.php
+++ b/src/Exporter/AbstractExcelExporter.php
@@ -13,17 +13,16 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\Exporter;
 
-use Contao\Database\Result;
 use Contao\File;
 use Contao\Files;
 use Contao\FilesModel;
-use Haste\IO\Reader\ArrayReader;
-use Haste\IO\Writer\ExcelFileWriter;
+use Contao\System;
 use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
 use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Exception;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\IWriter;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractExcelExporter extends AbstractExporter
@@ -39,82 +38,41 @@ abstract class AbstractExcelExporter extends AbstractExporter
     /**
      * Exports based on Excel format.
      *
-     * @param Result|object $config
-     * @param array|null $ids
-     * @param string $format
-     *
-     * @return File
      * @throws \Exception
      */
-    protected function exportWithFormat($config, $ids, $format)
+    protected function exportWithFormat(\stdClass $config, ?array $ids, string $format): File
     {
-        $dataCollector = $this->prepareDefaultDataCollector($config, $ids);
-
-        $reader = new ArrayReader($dataCollector->getExportData());
-
-        if ($config->headerFields) {
-            $reader->setHeaderFields($this->prepareDefaultHeaderFields($config, $dataCollector));
-        }
-
-        $columnConfig = $this->prepareDefaultExportConfig($config, $dataCollector);
-
         if ($config->useTemplate) {
-            return $this->exportWithTemplate($config, $columnConfig, $reader, $format);
+            $sheet = $this->getSheetTemplate($config, $format);
+        } else {
+            $sheet = new Spreadsheet();
         }
 
-        return $this->exportWithoutTemplate($config, $columnConfig, $reader, $format);
+        $sheet = $this->writeDataToSheet($sheet, $config, $ids);
+        $writer = IOFactory::createWriter($sheet, $format);
+
+        return $this->exportWriter($writer, $config);
     }
 
     /**
-     * Default export without template.
-     *
-     * @param $config
-     * @param $format
-     *
-     * @return File
-     * @throws ExportFailedException|\Exception
-     *
+     * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception|\Exception
      */
-    protected function exportWithoutTemplate(
-        $config,
-        array $columnConfig,
-        ArrayReader $reader,
-        $format
-    ) {
-        $writer = new ExcelFileWriter('system/tmp/'.$this->exportFile->getFilenameForConfig($config));
-        $writer->setFormat($format);
-
-        // Add header fields
-        if ($config->headerFields) {
-            $writer->enableHeaderFields();
-        }
-
-        $writer->setRowCallback(function ($data) use ($config, $columnConfig) {
-            return $this->dataTransformer->compileRow($data, $config, $columnConfig);
-        });
-
-        $this->handleDefaultExportResult($writer->writeFrom($reader));
+    protected function exportWriter(IWriter $writer, \stdClass $config): File
+    {
+        $projectDir = System::getContainer()->getParameter('kernel.project_dir');
+        $fileName = 'system/tmp/'.$this->exportFile->getFilenameForConfig($config);
+        $writer->save($projectDir.'/'.$fileName);
 
         $this->updateLastRun($config);
 
-        return new File($writer->getFilename());
+        return new File($fileName);
     }
 
     /**
-     * Export with template.
-     *
-     * @param $config
-     * @param $format
-     *
-     * @return File
      * @throws Exception|\Exception
      */
-    protected function exportWithTemplate(
-        $config,
-        array $columnConfig,
-        ArrayReader $reader,
-        $format
-    ) {
+    protected function getSheetTemplate(\stdClass $config, string $format): Spreadsheet
+    {
         // Fetch the template and make a copy of it
         $template = FilesModel::findByPk($config->template);
 
@@ -126,48 +84,64 @@ abstract class AbstractExcelExporter extends AbstractExporter
         $tmpPath = 'system/tmp/'.$this->exportFile->getFilenameForConfig($config);
         Files::getInstance()->copy($template->path, $tmpPath);
 
-        $excelReader = IOFactory::createReader($format);
-        $excel = $excelReader->load(TL_ROOT.'/'.$tmpPath);
+        $reader = IOFactory::createReader($format);
+        $projectDir = System::getContainer()->getParameter('kernel.project_dir');
+        $sheet = $reader->load($projectDir.'/'.$tmpPath);
 
-        $excel->setActiveSheetIndex((int) $config->sheetIndex);
-        $sheet = $excel->getActiveSheet();
+        $sheet->setActiveSheetIndex((int)$config->sheetIndex);
 
-        $currentRow = (int) $config->startIndex ?: 1;
-        $currentColumn = 0;
+        return $sheet;
+    }
 
-        foreach ($reader as $readerRow) {
-            $compiledRow = $this->dataTransformer->compileRow($readerRow, $config, $columnConfig);
+    /**
+     * @throws Exception
+     */
+    protected function writeDataToSheet(Spreadsheet $sheet, \stdClass $config, $ids = null): Spreadsheet
+    {
+        $currentRow = (int)$config->startIndex ?: 1;
+        $dataCollector = $this->prepareDefaultDataCollector($config, $ids);
+        $columnConfigs = $this->prepareDefaultExportConfig($config, $dataCollector);
 
-            foreach ($compiledRow as $k => $value) {
-                // Support explicit target column
-                if ('tokens' === $config->export && isset($config->tokenFields[$k]['targetColumn'])) {
-                    $column = $config->tokenFields[$k]['targetColumn'];
-
-                    if (!is_numeric($column)) {
-                        $column = Coordinate::columnIndexFromString($column) - 1;
-                    }
-                } else {
-                    // Use next column, ignoring explicit target columns in the counter
-                    $column = $currentColumn++;
-                }
-
-                $sheet->setCellValueExplicitByColumnAndRow(
-                    $column,
-                    $currentRow,
-                    (string) $value,
-                    DataType::TYPE_STRING2
-                );
-            }
-
-            $currentColumn = 0;
-            ++$currentRow;
+        // Add header fields
+        if ($config->headerFields) {
+            $headerRow = $this->prepareDefaultHeaderFields($config, $dataCollector);
+            $currentRow = $this->writeRowToSheet($sheet, $currentRow, $headerRow, $config);
         }
 
-        $excelWriter = IOFactory::createWriter($excel, $format);
-        $excelWriter->save(TL_ROOT.'/'.$tmpPath);
+        foreach ($dataCollector->getExportData() as $row) {
+            $compiledRow = $this->dataTransformer->compileRow($row, $config, $columnConfigs);
+            $currentRow = $this->writeRowToSheet($sheet, $currentRow, $compiledRow, $config);
+        }
 
-        $this->updateLastRun($config);
+        $this->handleDefaultExportResult($currentRow);
 
-        return new File($tmpPath);
+        return $sheet;
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function writeRowToSheet(Spreadsheet $sheet, int $currentRow, array $row, \stdClass $config): int
+    {
+        $currentColumn = 0;
+        foreach ($row as $k => $value) {
+            // Support explicit target column
+            if ('tokens' === $config->export && isset($config->tokenFields[$k]['targetColumn'])) {
+                $column = $config->tokenFields[$k]['targetColumn'];
+
+                if (!is_numeric($column)) {
+                    $column = Coordinate::columnIndexFromString($column) - 1;
+                }
+            } else {
+                // Use next column, ignoring explicit target columns in the counter
+                $column = ++$currentColumn;
+            }
+            $sheet->getActiveSheet()->getCell(
+                Coordinate::stringFromColumnIndex($column).$currentRow
+            )->setValueExplicit((string)$value, DataType::TYPE_STRING2);
+        }
+        ++$currentRow;
+
+        return $currentRow;
     }
 }

--- a/src/Exporter/AbstractExcelExporter.php
+++ b/src/Exporter/AbstractExcelExporter.php
@@ -17,8 +17,10 @@ use Contao\Files;
 use Contao\FilesModel;
 use Haste\IO\Reader\ArrayReader;
 use Haste\IO\Writer\ExcelFileWriter;
-use PHPExcel_Cell;
-use PHPExcel_IOFactory;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use Symfony\Component\HttpFoundation\Response;
 
 abstract class AbstractExcelExporter extends AbstractExporter
@@ -28,7 +30,7 @@ abstract class AbstractExcelExporter extends AbstractExporter
      */
     public function isAvailable(): bool
     {
-        return class_exists('PhpOffice\PhpSpreadsheet\Spreadsheet') || (class_exists('PHPExcel') && class_exists('PHPExcel_IOFactory'));
+        return class_exists(Spreadsheet::class);
     }
 
     /**
@@ -119,7 +121,7 @@ abstract class AbstractExcelExporter extends AbstractExporter
         $tmpPath = 'system/tmp/'.$this->exportFile->getFilenameForConfig($config);
         Files::getInstance()->copy($template->path, $tmpPath);
 
-        $excelReader = PHPExcel_IOFactory::createReader($format);
+        $excelReader = IOFactory::createReader($format);
         $excel = $excelReader->load(TL_ROOT.'/'.$tmpPath);
 
         $excel->setActiveSheetIndex((int) $config->sheetIndex);
@@ -137,7 +139,7 @@ abstract class AbstractExcelExporter extends AbstractExporter
                     $column = $config->tokenFields[$k]['targetColumn'];
 
                     if (!is_numeric($column)) {
-                        $column = PHPExcel_Cell::columnIndexFromString($column) - 1;
+                        $column = Coordinate::columnIndexFromString($column) - 1;
                     }
                 } else {
                     // Use next column, ignoring explicit target columns in the counter
@@ -148,7 +150,7 @@ abstract class AbstractExcelExporter extends AbstractExporter
                     $column,
                     $currentRow,
                     (string) $value,
-                    \PHPExcel_Cell_DataType::TYPE_STRING2
+                    DataType::TYPE_STRING2
                 );
             }
 
@@ -156,7 +158,7 @@ abstract class AbstractExcelExporter extends AbstractExporter
             ++$currentRow;
         }
 
-        $excelWriter = \PHPExcel_IOFactory::createWriter($excel, $format);
+        $excelWriter = IOFactory::createWriter($excel, $format);
         $excelWriter->save(TL_ROOT.'/'.$tmpPath);
 
         $this->updateLastRun($config);

--- a/src/Exporter/CsvExporter.php
+++ b/src/Exporter/CsvExporter.php
@@ -18,6 +18,9 @@ class CsvExporter extends AbstractExporter
         return true;
     }
 
+    /**
+     * @throws \Exception
+     */
     public function export(\stdClass $config, $ids = null): File
     {
         $dataCollector = $this->prepareDefaultDataCollector($config, $ids);

--- a/src/Exporter/XlsExporter.php
+++ b/src/Exporter/XlsExporter.php
@@ -17,6 +17,6 @@ class XlsExporter extends AbstractExcelExporter
      */
     public function export(\stdClass $config, $ids = null): File
     {
-        return $this->exportWithFormat($config, $ids, 'Excel5');
+        return $this->exportWithFormat($config, $ids, 'Xls');
     }
 }

--- a/src/Exporter/XlsxExporter.php
+++ b/src/Exporter/XlsxExporter.php
@@ -17,6 +17,6 @@ class XlsxExporter extends AbstractExcelExporter
      */
     public function export(\stdClass $config, $ids = null): File
     {
-        return $this->exportWithFormat($config, $ids, 'Excel2007');
+        return $this->exportWithFormat($config, $ids, 'Xlsx');
     }
 }

--- a/src/Security/LeadVoter.php
+++ b/src/Security/LeadVoter.php
@@ -7,7 +7,6 @@ namespace Terminal42\LeadsBundle\Security;
 use Contao\BackendUser;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authorization\Voter\Voter;
-use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 
 class LeadVoter extends Voter
 {


### PR DESCRIPTION
I continued the work of @qzminski to support haste 5

- [x] Refactor usage of \Haste\Util\StringUtil to \Codefog\HasteBundle\StringParser
- [x] Refactor usage of \Haste\Http\Response\Response to \Symfony\Component\HttpFoundation\Response
- [x] Upgrade to menatwork/contao-multicolumnwizard-bundle
- [x] Fix compatibility of export with PhpSpreadsheet
- [x] Drop support of phpoffice/phpexcel
- [x] Refactor haste IO to PhpSpreadsheet (Csv now also via spreadsheet)
- [ ] Export with template should be tested - I had no working config