### PR TITLE
Fix query for grouped columns in AbstractExporter

### DIFF
--- a/src/Export/AbstractExporter.php
+++ b/src/Export/AbstractExporter.php
@@ -204,7 +204,7 @@ abstract class AbstractExporter implements ExporterInterface
                             JOIN tl_lead l ON l.id = d.pid
                             LEFT JOIN tl_form_field ff ON ff.id=d.main_id
                         WHERE l.main_id = ?
-                        GROUP BY d.main_id, d.name
+                        GROUP BY d.main_id, ff.label, d.name
                         ORDER BY MIN(d.sorting)
                     SQL,
                 [$this->config['pid']]


### PR DESCRIPTION
Without the `ff.label` in the `GROUP BY` of the query you will get the following error:
`An exception occurred while executing a query: SQLSTATE[42000]: Syntax error or access violation: 1055 'xxx.ff.label' isn't in GROUP BY"
`