### PR TITLE
Fixed compatibility with Contao 5.4/Symfony 7

### DIFF
--- a/src/EventListener/DataContainer/ExportAccessListener.php
+++ b/src/EventListener/DataContainer/ExportAccessListener.php
@@ -12,7 +12,7 @@ use Contao\Input;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 #[AsCallback('tl_lead_export', 'config.onload')]
 class ExportAccessListener
@@ -21,7 +21,7 @@ class ExportAccessListener
         private readonly Connection $connection,
         private readonly RequestStack $requestStack,
         private readonly ScopeMatcher $scopeMatcher,
-        private readonly Security $security,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
     ) {
     }
 
@@ -44,7 +44,7 @@ class ExportAccessListener
 
     protected function denyAccessUnlessGranted(mixed $attribute, mixed $subject = null, string $message = 'Access Denied.'): void
     {
-        if (!$this->security->isGranted($attribute, $subject)) {
+        if (!$this->authorizationChecker->isGranted($attribute, $subject)) {
             $exception = new AccessDeniedException($message);
             $exception->setAttributes($attribute);
             $exception->setSubject($subject);

--- a/src/EventListener/DataContainer/ExportButtonsListener.php
+++ b/src/EventListener/DataContainer/ExportButtonsListener.php
@@ -11,8 +11,8 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
 use Terminal42\LeadsBundle\Export\ExporterInterface;
 
@@ -25,7 +25,7 @@ class ExportButtonsListener
     public function __construct(
         private readonly Connection $connection,
         private readonly RequestStack $requestStack,
-        private readonly Security $security,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly TranslatorInterface $translator,
         private readonly ServiceLocator $exporters,
     ) {
@@ -59,7 +59,7 @@ class ExportButtonsListener
 
     protected function denyAccessUnlessGranted(mixed $attribute, mixed $subject = null, string $message = 'Access Denied.'): void
     {
-        if (!$this->security->isGranted($attribute, $subject)) {
+        if (!$this->authorizationChecker->isGranted($attribute, $subject)) {
             $exception = new AccessDeniedException($message);
             $exception->setAttributes($attribute);
             $exception->setSubject($subject);

--- a/src/EventListener/DataContainer/ExportOperationsListener.php
+++ b/src/EventListener/DataContainer/ExportOperationsListener.php
@@ -11,7 +11,7 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsCallback('tl_lead', 'config.onload')]
@@ -20,7 +20,7 @@ class ExportOperationsListener
     public function __construct(
         private readonly Connection $connection,
         private readonly RequestStack $requestStack,
-        private readonly Security $security,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly TranslatorInterface $translator,
         private readonly Packages $packages,
@@ -55,8 +55,8 @@ class ExportOperationsListener
         }
 
         if (
-            $this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form')
-            && $this->security->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE, 'tl_lead_export')
+            $this->authorizationChecker->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'form')
+            && $this->authorizationChecker->isGranted(ContaoCorePermissions::USER_CAN_EDIT_FIELDS_OF_TABLE, 'tl_lead_export')
         ) {
             $operations[] = [
                 'label' => [

--- a/src/EventListener/DataContainer/FormMainOptionsListener.php
+++ b/src/EventListener/DataContainer/FormMainOptionsListener.php
@@ -8,14 +8,14 @@ use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\DataContainer;
 use Doctrine\DBAL\Connection;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 #[AsCallback('tl_form', 'fields.leadMain.options')]
 class FormMainOptionsListener
 {
     public function __construct(
         private readonly Connection $connection,
-        private readonly Security $security,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
     ) {
     }
 
@@ -29,7 +29,7 @@ class FormMainOptionsListener
         );
 
         foreach ($forms as $form) {
-            if (!$this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_FORM, $form['id'])) {
+            if (!$this->authorizationChecker->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_FORM, $form['id'])) {
                 continue;
             }
 

--- a/src/EventListener/DataContainer/LeadAccessListener.php
+++ b/src/EventListener/DataContainer/LeadAccessListener.php
@@ -12,7 +12,7 @@ use Doctrine\DBAL\Connection;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 #[AsCallback('tl_lead', 'config.onload')]
 #[AsCallback('tl_lead_data', 'config.onload')]
@@ -22,7 +22,7 @@ class LeadAccessListener
         private readonly Connection $connection,
         private readonly RequestStack $requestStack,
         private readonly ScopeMatcher $scopeMatcher,
-        private readonly Security $security,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly Packages $packages,
     ) {
     }
@@ -56,7 +56,7 @@ class LeadAccessListener
             $formId = $request->query->getInt('form');
         }
 
-        if (!$this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_FORM, $formId)) {
+        if (!$this->authorizationChecker->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_FORM, $formId)) {
             $exception = new AccessDeniedException('Not enough permissions to access leads ID "'.$formId.'"');
             $exception->setAttributes(ContaoCorePermissions::USER_CAN_ACCESS_FORM);
             $exception->setSubject($formId);

--- a/src/EventListener/DataContainer/UserPermissionsListener.php
+++ b/src/EventListener/DataContainer/UserPermissionsListener.php
@@ -5,25 +5,25 @@ declare(strict_types=1);
 namespace Terminal42\LeadsBundle\EventListener\DataContainer;
 
 use Contao\CoreBundle\DependencyInjection\Attribute\AsCallback;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Terminal42\LeadsBundle\Security\Terminal42LeadsPermissions;
 
 #[AsCallback('tl_lead', 'config.onload')]
 #[AsCallback('tl_lead_data', 'config.onload')]
 class UserPermissionsListener
 {
-    public function __construct(private readonly Security $security)
+    public function __construct(private readonly AuthorizationCheckerInterface $authorizationChecker)
     {
     }
 
     public function __invoke(): void
     {
-        if (!empty($GLOBALS['TL_DCA']['tl_lead']) && !$this->security->isGranted(Terminal42LeadsPermissions::USER_CAN_DELETE_LEADS)) {
+        if (!empty($GLOBALS['TL_DCA']['tl_lead']) && !$this->authorizationChecker->isGranted(Terminal42LeadsPermissions::USER_CAN_DELETE_LEADS)) {
             $GLOBALS['TL_DCA']['tl_lead']['config']['notDeletable'] = true;
             unset($GLOBALS['TL_DCA']['tl_lead']['list']['operations']['delete']);
         }
 
-        if (!empty($GLOBALS['TL_DCA']['tl_lead_data']) && !$this->security->isGranted(Terminal42LeadsPermissions::USER_CAN_EDIT_LEAD_DATA)) {
+        if (!empty($GLOBALS['TL_DCA']['tl_lead_data']) && !$this->authorizationChecker->isGranted(Terminal42LeadsPermissions::USER_CAN_EDIT_LEAD_DATA)) {
             $GLOBALS['TL_DCA']['tl_lead_data']['config']['notEditable'] = true;
             unset($GLOBALS['TL_DCA']['tl_lead_data']['list']['operations']['edit']);
         }

--- a/src/EventListener/ProcessFormDataListener.php
+++ b/src/EventListener/ProcessFormDataListener.php
@@ -12,7 +12,7 @@ use Contao\StringUtil;
 use Contao\Validator;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Symfony\Component\Security\Core\Security;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Terminal42\LeadsBundle\Event\FormDataLabelEvent;
 use Terminal42\LeadsBundle\Event\FormDataValueEvent;
@@ -23,7 +23,7 @@ class ProcessFormDataListener
     public function __construct(
         private readonly Connection $connection,
         private readonly RequestStack $requestStack,
-        private readonly Security $security,
+        private readonly TokenStorageInterface $tokenStorage,
         private readonly EventDispatcherInterface $eventDispatcher,
     ) {
     }
@@ -45,7 +45,7 @@ class ProcessFormDataListener
     private function saveLead(array $postData, array $formConfig): int
     {
         $request = $this->requestStack->getCurrentRequest();
-        $user = $this->security->getUser();
+        $user = $this->tokenStorage->getToken()?->getUser();
 
         $this->connection->insert('tl_lead', [
             'tstamp' => time(),

--- a/src/EventListener/UserNavigationListener.php
+++ b/src/EventListener/UserNavigationListener.php
@@ -9,10 +9,10 @@ use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
+use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
-use Symfony\Component\Security\Core\Security;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsHook('initializeSystem')]

--- a/src/EventListener/UserNavigationListener.php
+++ b/src/EventListener/UserNavigationListener.php
@@ -26,7 +26,7 @@ class UserNavigationListener
         private readonly Connection $connection,
         private readonly RequestStack $requestStack,
         private readonly ScopeMatcher $scopeMatcher,
-        private readonly AuthorizationCheckerInterface $security,
+        private readonly AuthorizationCheckerInterface $authorizationChecker,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly TranslatorInterface $translator,
         private readonly Packages $packages,
@@ -120,7 +120,7 @@ class UserNavigationListener
 
         $forms = $this->connection->fetchAllAssociative("SELECT id, title, leadMenuLabel FROM tl_form WHERE leadEnabled='1' AND leadMain=0");
 
-        if ($this->security->isGranted('ROLE_ADMIN')) {
+        if ($this->authorizationChecker->isGranted('ROLE_ADMIN')) {
             // Find lead records where the related form has been deleted
             $forms = array_merge($forms, $this->connection->fetchAllAssociative(
                 <<<'SQL'
@@ -138,7 +138,7 @@ class UserNavigationListener
             // Remove forms the user does not have access to
             $forms = array_filter(
                 $forms,
-                fn (array $form) => $this->security->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_FORM, $form['id']),
+                fn (array $form) => $this->authorizationChecker->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_FORM, $form['id']),
             );
         }
 

--- a/src/EventListener/UserNavigationListener.php
+++ b/src/EventListener/UserNavigationListener.php
@@ -9,10 +9,10 @@ use Contao\CoreBundle\Routing\ScopeMatcher;
 use Contao\CoreBundle\Security\ContaoCorePermissions;
 use Contao\StringUtil;
 use Doctrine\DBAL\Connection;
-use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\Asset\Packages;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 #[AsHook('initializeSystem')]
@@ -26,7 +26,7 @@ class UserNavigationListener
         private readonly Connection $connection,
         private readonly RequestStack $requestStack,
         private readonly ScopeMatcher $scopeMatcher,
-        private readonly Security $security,
+        private readonly AuthorizationCheckerInterface $security,
         private readonly UrlGeneratorInterface $urlGenerator,
         private readonly TranslatorInterface $translator,
         private readonly Packages $packages,


### PR DESCRIPTION
Symfony Security Class was removed in Contao 5.4/Symfony 7.
Changed it to AuthorizationCheckerInterface for isGranted function and to TokenStorageInterface for getUser function.