### PR TITLE
Bump phpspreadsheet versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "contao/core-bundle": "^4.13 || ^5.0",
         "codefog/contao-haste": "^4.25 || ^5.0",
         "menatwork/contao-multicolumnwizard-bundle": "^3.6",
-        "phpoffice/phpspreadsheet": "^1.26 || ^2.0",
+        "phpoffice/phpspreadsheet": "^1.29.1 || ^2.2.1",
         "doctrine/dbal": "^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/asset": "^5.0 || ^6.0 || ^7.0",


### PR DESCRIPTION
### Description

Bumps versions of PHPOffice/PhpSpreadsheet to fix the following security issues:

* https://github.com/advisories/GHSA-ghg6-32f9-2jp7
* https://github.com/advisories/GHSA-wgmf-q9vr-vww6

They did backport the security patch to version 1 as well.
https://github.com/PHPOffice/PhpSpreadsheet/releases/tag/1.29.1
