### PR TITLE
Fix non-empty label preference in backed lead list

### DIFF
--- a/src/EventListener/DataContainer/LeadLabelListener.php
+++ b/src/EventListener/DataContainer/LeadLabelListener.php
@@ -48,8 +48,17 @@ class LeadLabelListener
         $records = $this->connection->fetchAllAssociative('SELECT name, value, label FROM tl_lead_data WHERE pid=?', [$row['id']]);
 
         foreach ($records as $record) {
-            $label = StringUtil::deserialize($record['label']);
-            $value = (!\is_array($label) && !empty($label)) || (\is_array($label) && array_filter($label)) ? $label : StringUtil::deserialize($record['value']);
+            // Try to use label over value if it is a non-empty scalar value or a non-empty array
+            foreach ([$record['label'], $record['value']] as $value) {
+                $value = StringUtil::deserialize($value);
+
+                if (
+                    (!\is_array($value) && '' !== (string) $value)
+                    || (\is_array($value) && [] !== array_filter($value))
+                ) {
+                    break;
+                }
+            }
 
             if ($this->stringParser) {
                 $this->stringParser->flatten($value, $record['name'], $tokens);

--- a/src/EventListener/DataContainer/LeadLabelListener.php
+++ b/src/EventListener/DataContainer/LeadLabelListener.php
@@ -47,11 +47,13 @@ class LeadLabelListener
 
         $records = $this->connection->fetchAllAssociative('SELECT name, value, label FROM tl_lead_data WHERE pid=?', [$row['id']]);
 
-        foreach ($records as $record) {
+        foreach ($records as $record) {            
+            $label = StringUtil::deserialize($record['label']);
+            $value = (is_array($label) && array_filter($label)) || (!is_array($label) && !empty($label)) ? $label : StringUtil::deserialize($record['value']);
             if ($this->stringParser) {
-                $this->stringParser->flatten(StringUtil::deserialize($record['label'] ?: $record['value']), $record['name'], $tokens);
+                $this->stringParser->flatten($value, $record['name'], $tokens);
             } else {
-                \Haste\Util\StringUtil::flatten(StringUtil::deserialize($record['label'] ?: $record['value']), $record['name'], $tokens);
+                \Haste\Util\StringUtil::flatten($value, $record['name'], $tokens);
             }
         }
 

--- a/src/EventListener/DataContainer/LeadLabelListener.php
+++ b/src/EventListener/DataContainer/LeadLabelListener.php
@@ -47,9 +47,10 @@ class LeadLabelListener
 
         $records = $this->connection->fetchAllAssociative('SELECT name, value, label FROM tl_lead_data WHERE pid=?', [$row['id']]);
 
-        foreach ($records as $record) {            
+        foreach ($records as $record) {
             $label = StringUtil::deserialize($record['label']);
-            $value = (is_array($label) && array_filter($label)) || (!is_array($label) && !empty($label)) ? $label : StringUtil::deserialize($record['value']);
+            $value = (!\is_array($label) && !empty($label)) || (\is_array($label) && array_filter($label)) ? $label : StringUtil::deserialize($record['value']);
+
             if ($this->stringParser) {
                 $this->stringParser->flatten($value, $record['name'], $tokens);
             } else {


### PR DESCRIPTION
Fixes https://github.com/terminal42/contao-leads/issues/162 with incorrect label resolution in the label listener when label and value data are arrays.

Previously, the label listener incorrectly handled label and value data provided as arrays. This PR ensures that the correct label is used by iterating over both arrays and prioritizing non-empty labels.