### PR TITLE
Add back end module check

### DIFF
--- a/src/EventListener/UserNavigationListener.php
+++ b/src/EventListener/UserNavigationListener.php
@@ -79,6 +79,10 @@ class UserNavigationListener
      */
     public function onGetUserNavigation(array $modules): array
     {
+        if (!$this->authorizationChecker->isGranted(ContaoCorePermissions::USER_CAN_ACCESS_MODULE, 'lead')) {
+            return $modules;
+        }
+
         $forms = $this->getForms();
 
         if (empty($forms)) {


### PR DESCRIPTION
If a user does not have access to the `lead` back end module in their group settings, the following error will currently occur:

```
ErrorException:
Warning: Undefined array key "label"

  at vendor\contao\core-bundle\src\EventListener\Menu\BackendMenuListener.php:75
  at Contao\CoreBundle\EventListener\Menu\BackendMenuListener->buildMainMenu(object(MenuEvent), object(BackendUser))
     (vendor\contao\core-bundle\src\EventListener\Menu\BackendMenuListener.php:56)
  at Contao\CoreBundle\EventListener\Menu\BackendMenuListener->__invoke(object(MenuEvent), 'contao.backend_menu_build', object(TraceableEventDispatcher))
     (vendor\symfony\event-dispatcher\Debug\WrappedListener.php:118)
  at Symfony\Component\EventDispatcher\Debug\WrappedListener->__invoke(object(MenuEvent), 'contao.backend_menu_build', object(TraceableEventDispatcher))
     (vendor\symfony\event-dispatcher\EventDispatcher.php:230)
  at Symfony\Component\EventDispatcher\EventDispatcher->callListeners(array(object(WrappedListener), object(WrappedListener), object(WrappedListener), object(WrappedListener)), 'contao.backend_menu_build', object(MenuEvent))
     (vendor\symfony\event-dispatcher\EventDispatcher.php:59)
  at Symfony\Component\EventDispatcher\EventDispatcher->dispatch(object(MenuEvent), 'contao.backend_menu_build')
     (vendor\symfony\event-dispatcher\Debug\TraceableEventDispatcher.php:154)
  at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch(object(MenuEvent), 'contao.backend_menu_build')
     (vendor\contao\core-bundle\src\Menu\BackendMenuBuilder.php:42)
  at Contao\CoreBundle\Menu\BackendMenuBuilder->buildMainMenu(array())
     (vendor\knplabs\knp-menu\src\Knp\Menu\Provider\LazyProvider.php:39)
  at Knp\Menu\Provider\LazyProvider->get('be_menu', array())
     (vendor\knplabs\knp-menu\src\Knp\Menu\Provider\ChainProvider.php:26)
  at Knp\Menu\Provider\ChainProvider->get('be_menu', array())
     (vendor\knplabs\knp-menu\src\Knp\Menu\Twig\Helper.php:43)
  at Knp\Menu\Twig\Helper->get('be_menu', array())
     (vendor\knplabs\knp-menu\src\Knp\Menu\Twig\Helper.php:142)
  at Knp\Menu\Twig\Helper->castMenu('be_menu')
     (vendor\knplabs\knp-menu\src\Knp\Menu\Twig\Helper.php:75)
  at Knp\Menu\Twig\Helper->render('be_menu', array(), null)
     (vendor\knplabs\knp-menu\src\Knp\Menu\Twig\MenuExtension.php:73)
  at Knp\Menu\Twig\MenuExtension->render('be_menu')
     (var\cache\dev\twig\e2\e2f6004b8a7987f4e4613cc3c7b1d30d.php:62)
  at __TwigTemplate_04d06aa6eece0e811370c7892dbb645c->doDisplay(array('app' => object(AppVariable)), array())
     (vendor\twig\twig\src\Template.php:387)
  at Twig\Template->yield(array('app' => object(AppVariable)), array())
     (vendor\twig\twig\src\Template.php:343)
  at Twig\Template->display(array())
     (vendor\twig\twig\src\Template.php:358)
  at Twig\Template->render(array())
     (vendor\twig\twig\src\TemplateWrapper.php:35)
  at Twig\TemplateWrapper->render(array())
     (vendor\twig\twig\src\Environment.php:320)
  at Twig\Environment->render('@ContaoCore/Backend/be_menu.html.twig')
     (vendor\contao\core-bundle\src\Resources\contao\controllers\BackendMain.php:271)
  …
```

This is because Contao will not pre-fill the `$modules` array with the `lead` module and its label if access to the `lead` back end module is not granted. But the `onGestUserNavigation` listener will still add the leads the user has access to, thus the rest of the data for the back end navigation (like the label etc.) will be missing.