### PR TITLE
Encode special characters in `list.label.label` callback

### DIFF
--- a/src/EventListener/DataContainer/LeadLabelListener.php
+++ b/src/EventListener/DataContainer/LeadLabelListener.php
@@ -68,10 +68,13 @@ class LeadLabelListener
         }
 
         if ($this->stringParser) {
-            return StringUtil::specialchars($this->stringParser->recursiveReplaceTokensAndTags($lead['leadLabel'], $tokens));
+            $return = $this->stringParser->recursiveReplaceTokensAndTags($lead['leadLabel'], $tokens);
+        } else {
+            $return = \Haste\Util\StringUtil::recursiveReplaceTokensAndTags($lead['leadLabel'], $tokens);
         }
 
-        return StringUtil::specialchars(\Haste\Util\StringUtil::recursiveReplaceTokensAndTags($lead['leadLabel'], $tokens));
+        // Encode specialchars for the back end view (see terminal42/contao-leads#170)
+        return StringUtil::specialchars($return);
     }
 
     private function formatToken(string $title, int|string $value): string

--- a/src/EventListener/DataContainer/LeadLabelListener.php
+++ b/src/EventListener/DataContainer/LeadLabelListener.php
@@ -68,10 +68,10 @@ class LeadLabelListener
         }
 
         if ($this->stringParser) {
-            return $this->stringParser->recursiveReplaceTokensAndTags($lead['leadLabel'], $tokens);
+            return StringUtil::specialchars($this->stringParser->recursiveReplaceTokensAndTags($lead['leadLabel'], $tokens));
         }
 
-        return \Haste\Util\StringUtil::recursiveReplaceTokensAndTags($lead['leadLabel'], $tokens);
+        return StringUtil::specialchars(\Haste\Util\StringUtil::recursiveReplaceTokensAndTags($lead['leadLabel'], $tokens));
     }
 
     private function formatToken(string $title, int|string $value): string


### PR DESCRIPTION
A customer wanted to use a lead label like this:

```
##_created## | ##firstname## ##lastname## <##email##>
```

However, the `<` and `>` are output as is, leading to invalid HTML in the back end view. This PR ensures that special characters are always replaced with their entities for the `list.label.label` callback.

_Note:_ the main reason for this is, that `Codefog\HasteBundle\StringParser::recursiveReplaceTokensAndTags()` always executes `StringUtil::decodeEntities()` on the given `$text`.