### PR TITLE
Skip expression syntax errors

### DIFF
--- a/src/Export/AbstractExporter.php
+++ b/src/Export/AbstractExporter.php
@@ -228,6 +228,8 @@ abstract class AbstractExporter implements ExporterInterface
                     }
                 } catch (SyntaxError $e) {
                     $this->logger?->error(\sprintf('Could not evaluate export filter expression for lead %s', $lead['id']), ['exception' => $e]);
+
+                    continue;
                 }
 
                 yield $data;

--- a/src/Export/PhpSpreadsheetExporter.php
+++ b/src/Export/PhpSpreadsheetExporter.php
@@ -11,6 +11,7 @@ use PhpOffice\PhpSpreadsheet\Cell\IValueBinder;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\Csv;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Contracts\Translation\TranslatorInterface;
@@ -36,8 +37,9 @@ class PhpSpreadsheetExporter extends AbstractExporter
         TranslatorInterface $translator,
         StringParser $parser,
         ExpressionLanguage $expressionLanguage,
+        LoggerInterface|null $logger = null,
     ) {
-        parent::__construct($formatters, $connection, $translator, $parser, $expressionLanguage);
+        parent::__construct($formatters, $connection, $translator, $parser, $expressionLanguage, $logger);
     }
 
     protected function doExport($stream): void


### PR DESCRIPTION
I noticed two problems when using expressions for filtering an export:

If you have a syntax error in your expression and you try to download the file, there will be no error message telling you that a syntax error occurred. There will also be no error log entry and no error output whatsoever, even in `dev`. There will only be an empty `500` response. This is likely because the error occurs within the callback of the `StreamedResponse`.

Secondly, if your syntax is technically correct - there might still be a syntax error if an older lead happens to not have a specific field stored yet. For example you built a form, enabled the lead storage, collected some leads - but then later on you decide to add another form field, store that in the leads as well - and then filter on that form field for a specific export configuration.

For all the older leads that did not have that form field yet a syntax error will occur as that field will not be in the tokens for the `ExpressionLanguage`.

This PR adds catching the `SyntaxError` and simply ignoring it, if the expression cannot evaluate for a specific lead (for whatever reason). It will also add an error log entry like this:

```
[2025-03-20T17:50:47.694322+01:00] app.ERROR: Could not apply export filter expression for lead 123 {"exception":"[object] (Symfony\\Component\\ExpressionLanguage\\SyntaxError(code: 0): Variable \"foobar\" is not valid around position 1 for expression `foobar == '1'`. at vendor\\symfony\\expression-language\\Parser.php:230)"} []
```