### PR TITLE
Fix bitwise operator in recursiveReplaceTokensAndTags call

### DIFF
--- a/src/Export/AbstractExporter.php
+++ b/src/Export/AbstractExporter.php
@@ -356,7 +356,7 @@ abstract class AbstractExporter implements ExporterInterface
         $filename = $this->parser->recursiveReplaceTokensAndTags(
             $filename,
             $tokens,
-            StringParser::NO_TAGS & StringParser::NO_BREAKS & StringParser::NO_ENTITIES,
+            StringParser::NO_TAGS | StringParser::NO_BREAKS | StringParser::NO_ENTITIES,
         );
 
         if (!str_contains($filename, '.')) {


### PR DESCRIPTION
Please correct me if I'm missing some context here, but I believe the flags should be joined with `|` instead of `&`. To clarify my reasoning, I added the calculation below that shows how `&` clears all flags and `|` combines them.

From `Codefog\HasteBundle\StringParser`:
```php
public const NO_TAGS = 1;
public const NO_BREAKS = 2;
public const NO_EMAILS = 4;
public const NO_INSERTTAGS = 8;
public const NO_ENTITIES = 16;
```

```php
StringParser::NO_TAGS & StringParser::NO_BREAKS & StringParser::NO_ENTITIES
== 0b00001  // 1
 & 0b00010  // 2
 & 0b10000  // 16
== 0b00000  // 0 -> No flags set (equivalent to passing 0).
```

```php
StringParser::NO_TAGS | StringParser::NO_BREAKS | StringParser::NO_ENTITIES
== 0b00001  // 1
 | 0b00010  // 2
 | 0b10000  // 16
== 0b10011  // 19 -> Flags are set.
```

I much appreciate your time on this!

