### PR TITLE
Fix the entities not being properly handled in the menu titles

### DIFF
--- a/src/EventListener/UserNavigationListener.php
+++ b/src/EventListener/UserNavigationListener.php
@@ -98,7 +98,7 @@ class UserNavigationListener
             $formTitle = StringUtil::decodeEntities($form['title']);
 
             $modules['leads']['modules']['lead_'.$form['id']] = [
-                'title' => StringUtil::specialchars($this->translator->trans('MOD.leads.1', [$formTitle], 'contao_modules')),
+                'title' => $this->translator->trans('MOD.leads.1', [$formTitle], 'contao_modules'),
                 'label' => $form['leadMenuLabel'] ?: $formTitle,
                 'class' => 'navigation leads',
                 'href' => $this->urlGenerator->generate('contao_backend', ['do' => 'lead', 'form' => $form['id']]),


### PR DESCRIPTION
Before:

<img width="748" height="240" alt="CleanShot 2026-05-20 at 09 04 37" src="https://github.com/user-attachments/assets/1f349856-ef28-4c93-8337-7f510f2607f6" />

After:

<img width="780" height="188" alt="CleanShot 2026-05-20 at 09 06 17" src="https://github.com/user-attachments/assets/c82d5e52-aef0-4ca5-8084-740f2fe2b0d8" />
