### PR TITLE
Support multiple file uploads in lead data

### DIFF
--- a/src/EventListener/ProcessFormDataListener.php
+++ b/src/EventListener/ProcessFormDataListener.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Terminal42\LeadsBundle\EventListener;
 
+use Codefog\HasteBundle\FileUploadNormalizer;
 use Contao\CoreBundle\DependencyInjection\Attribute\AsHook;
 use Contao\Date;
 use Contao\FilesModel;
@@ -25,6 +26,7 @@ class ProcessFormDataListener
         private readonly RequestStack $requestStack,
         private readonly TokenStorageInterface $tokenStorage,
         private readonly EventDispatcherInterface $eventDispatcher,
+        private readonly FileUploadNormalizer $fileUploadNormalizer,
     ) {
     }
 
@@ -36,9 +38,10 @@ class ProcessFormDataListener
 
         $leadId = $this->saveLead($postData, $formConfig);
         $fields = $this->getFormFields((int) $formConfig['id'], (int) $formConfig['leadMain']);
+        $normalizedFiles = $this->fileUploadNormalizer->normalize($files ?? []);
 
         foreach ($fields as $field) {
-            $this->saveFormField($leadId, $field, $postData, $files);
+            $this->saveFormField($leadId, $field, $postData, $normalizedFiles);
         }
     }
 
@@ -99,12 +102,19 @@ class ProcessFormDataListener
         );
     }
 
-    private function saveFormField(int $leadId, array $field, array $postData, array|null $files): void
+    private function saveFormField(int $leadId, array $field, array $postData, array $normalizedFiles): void
     {
         $value = null;
 
-        if (null !== $files && isset($files[$field['postName']]) && ($files[$field['postName']]['uploaded'] ?? false)) {
-            $value = $this->prepareValue($files[$field['postName']], $field);
+        if (isset($normalizedFiles[$field['postName']])) {
+            $uploads = array_filter(
+                $normalizedFiles[$field['postName']],
+                static fn (array $file) => Validator::isUuid($file['uuid'] ?? null),
+            );
+
+            if ([] !== $uploads) {
+                $value = $this->prepareValue(array_values($uploads), $field);
+            }
         } elseif (isset($postData[$field['postName']])) {
             $value = $this->prepareValue($postData[$field['postName']], $field);
         }

--- a/src/Export/Format/UuidToFilePathFormatter.php
+++ b/src/Export/Format/UuidToFilePathFormatter.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Terminal42\LeadsBundle\Export\Format;
 
 use Contao\FilesModel;
+use Contao\StringUtil;
 use Contao\Validator;
 use Terminal42\LeadsBundle\DependencyInjection\Attribute\AsLeadsFormatter;
 
@@ -13,6 +14,10 @@ class UuidToFilePathFormatter implements FormatterInterface
 {
     public function format(mixed $value, string $type): int|string
     {
+        if (\is_array($values = StringUtil::deserialize($value))) {
+            return serialize(array_map(fn ($v) => $this->format($v, $type), $values));
+        }
+
         if (!Validator::isUuid($value)) {
             return $value;
         }


### PR DESCRIPTION
When "multipleFiles" is enabled, the upload widget returns a list of file arrays instead of a single one, so the "uploaded" check in saveFormField() never matched and the field was silently skipped (#187).

Normalize the uploaded files through Haste's FileUploadNormalizer, which also covers third-party upload widgets returning UUIDs, paths or the "field_0"/"field_1" convention. The files are then filtered by a valid UUID, replacing the previous "uploaded" flag: the normalizer sets that flag on every entry, whereas a missing UUID still means there is nothing persistently referenceable. Uploads without a UUID are skipped as before, and no row is written if none remains.

Upload fields therefore always store value and label as a serialized array, matching what the normalizer guarantees. Existing scalar values stay readable, so no migration is required.

UuidToFilePathFormatter now handles arrays as well, because AbstractExporter applies formatters before deserializing the value.